### PR TITLE
Force regenerating segment control

### DIFF
--- a/Sources/DSKit/ViewModels/Segment/DSSegmentViewModel.swift
+++ b/Sources/DSKit/ViewModels/Segment/DSSegmentViewModel.swift
@@ -45,6 +45,7 @@ public class DSSegmentVM: DSViewModel, Equatable, Hashable {
     
     public static func == (lhs: DSSegmentVM, rhs: DSSegmentVM) -> Bool {
         return lhs.segments == rhs.segments &&
+            lhs.selectedSegmentIndex == rhs.selectedSegmentIndex &&
             lhs.insets == rhs.insets &&
             lhs.type == rhs.type &&
             lhs.accessibilityIdentifier == rhs.accessibilityIdentifier &&


### PR DESCRIPTION
...when selected segment index has changed in the view model.

- Let's have two segments which relate to 'Sign In' and a 'Sign Up' screens.
- On the 'Sign In' screen there is a button (or active text or whatever): 'Go to Sign Up'
- When user taps on this button I save the currently selected segment index and update the whole UI.
- The 'Sign In' screen (section) updates to 'Sign Up' screen (section) as expected but the segmented control remains unchanged, the selected section is still the 'Sign In' segment.

With this PR I solve this issue with forcing segment control to be regenerated also when selected segment index changed.

Please check whether this is a safe change and does not have any side effects. Thank you!