### PR TITLE
Handle validation border also when custom border style is applied

### DIFF
--- a/Sources/DSKit/Extensions/UIView+Border.swift
+++ b/Sources/DSKit/Extensions/UIView+Border.swift
@@ -1,0 +1,27 @@
+//
+//  UIView+Border.swift
+//  
+//
+//  Created by Zalan Mergl on 2022. 04. 14..
+//
+
+import UIKit
+
+public extension UIView {
+    func configureBorder(_ borderStyle: DSViewModelBorderStyle, viewColors: DSDesignableViewColors? = nil) {
+        switch borderStyle {
+        case .none:
+            layer.borderWidth = 0
+            layer.borderColor = UIColor.clear.cgColor
+        case .buttonColor:
+            layer.borderWidth = 2.0
+            layer.borderColor = viewColors?.button.background.cgColor ?? DSAppearance.shared.main.primaryView.button.background.cgColor
+        case .brandColor:
+            layer.borderWidth = 2.0
+            layer.borderColor = DSAppearance.shared.main.brandColor.cgColor
+        case .custom(width: let width, color: let color):
+            layer.borderWidth = width
+            layer.borderColor = color.cgColor
+        }
+    }
+}

--- a/Sources/DSKit/Extensions/UIView+DSViewModelDisplayStyle.swift
+++ b/Sources/DSKit/Extensions/UIView+DSViewModelDisplayStyle.swift
@@ -43,20 +43,7 @@ extension UIView {
         }
         
         // Border style
-        switch model.style.borderStyle {
-        case .none:
-            layer.borderWidth = 0
-            layer.borderColor = UIColor.clear.cgColor
-        case .buttonColor:
-            layer.borderWidth = 2.0
-            layer.borderColor = model.viewColors().button.background.cgColor
-        case .brandColor:
-            layer.borderWidth = 2.0
-            layer.borderColor = DSAppearance.shared.main.brandColor.cgColor
-        case .custom(width: let width, color: let color):
-            layer.borderWidth = width
-            layer.borderColor = color.cgColor
-        }
+        configureBorder(model.style.borderStyle, viewColors: model.viewColors())
         
         // Shadow style
         switch model.style.shadowStyle {

--- a/Sources/DSKit/ViewModels/TextField/DSTextFieldUIView.swift
+++ b/Sources/DSKit/ViewModels/TextField/DSTextFieldUIView.swift
@@ -69,6 +69,7 @@ final class DSTextFieldUIView: UIView, DSReusableUIView {
         // Textfield holder
         textFieldHolder.backgroundColor = colors.textField.background
         textFieldHolder.layer.cornerRadius = colors.cornerRadius
+        updateTextFieldHolderBorder()
         
         // Textfield colors
         textField.font = appearance.fonts.body.withSize(14)
@@ -169,14 +170,25 @@ final class DSTextFieldUIView: UIView, DSReusableUIView {
     
     /// Textfield valid style
     func validStyle() {
-        textFieldHolder.layer.borderWidth = 0
-        textFieldHolder.layer.borderColor = UIColor.clear.cgColor
+        updateTextFieldHolderBorder()
     }
     
     /// Textfield invalid style
     @objc func invalidStyle() {
-        textFieldHolder.layer.borderWidth = 1.0
-        textFieldHolder.layer.borderColor = UIColor.systemRed.cgColor
+        updateTextFieldHolderBorder(customColor: UIColor.systemRed)
+    }
+    
+    func updateTextFieldHolderBorder(customColor: UIColor? = nil) {
+        guard let viewModel = viewModel else {
+            return
+        }
+        
+        textFieldHolder.configureBorder(viewModel.borderStyle, viewColors: viewModel.viewColors())
+        
+        if let customColor = customColor {
+            textFieldHolder.layer.borderWidth = max(textFieldHolder.layer.borderWidth, 1.0)
+            textFieldHolder.layer.borderColor = customColor.cgColor
+        }
     }
     
     /// Hide invalid message

--- a/Sources/DSKit/ViewModels/TextField/DSTextFieldVM.swift
+++ b/Sources/DSKit/ViewModels/TextField/DSTextFieldVM.swift
@@ -39,8 +39,16 @@ public class DSTextFieldVM: DSViewModel, Equatable, Hashable {
     // Accessibility identifier
     public var accessibilityIdentifier: String = "TextField"
     
+    // Style of the border
+    public var borderStyle: DSViewModelBorderStyle = .none
+    
     /// Style
-    public var style: DSViewModelStyle = DSViewModelStyle()
+    public var style: DSViewModelStyle = DSViewModelStyle() {
+        didSet {
+            borderStyle = style.borderStyle
+            style.borderStyle = .none
+        }
+    }
     
     // Show an message when user type non valid text in textfield
     public var errorPlaceHolderText: String?


### PR DESCRIPTION
I found a bug with textfields.
I added custom border style to a text field this way:
```swift
let email = DSTextFieldVM.email(text: "imodeveloperlab@gmail.com", placeholder: "Email")
email.style = DSViewModelStyle(borderStyle: .brandColor)
```

But in this case when the validation failed the red border did not appear around the text field.

With this PR I tried to fix this issue but I am unsure if it's the best solution. Any suggestions are welcome.

With my "solution" DSKit user can now set custom border to a text field in two ways. Both do the same thing basically:
```swift
email.style = DSViewModelStyle(borderStyle: .brandColor)
```
or
```swift
email.borderStyle = .brandColor
```