### PR TITLE
Add possibility to set custom width for card items

### DIFF
--- a/Sources/DSKit/ViewModels/Card/DSCardVM.swift
+++ b/Sources/DSKit/ViewModels/Card/DSCardVM.swift
@@ -29,6 +29,7 @@ public struct DSCardVM: DSViewModel, Equatable, Hashable {
     public var gradientBottomColor: UIColor = .clear
     public var decorationImage: UIImage? = nil
     public var height: DSViewModelHeight?
+    public var width: DSViewModelWidth?
     
     public init(composer: DSTextComposer,
                 textPosition: DSCardTextPosition = .bottom,
@@ -74,6 +75,10 @@ public extension DSCardVM {
     
     func height(_ layoutEnvironment: NSCollectionLayoutEnvironment?, section: DSSection) -> DSViewModelHeight {
         return height ?? .absolute(200)
+    }
+    
+    func width(_ layoutEnvironment: NSCollectionLayoutEnvironment?, section: DSSection) -> DSViewModelWidth {
+        return width ?? .fractional(1.0)
     }
     
     func viewRepresentation() -> DSReusableUIView {


### PR DESCRIPTION
I use `DSCardVM` items in other contexts as well, e.g. in gallery of course or lesson list. In this case I noticed that the upcoming card is quite hardly recognizable. So I wanted to decrease the width of the cards in the gallery a little bit. But the `DSCardVM` model did not give the possibility to do that.

<img width="401" alt="Screenshot 2022-05-13 at 8 37 12" src="https://user-images.githubusercontent.com/4274056/168226543-51c96ef5-0f05-4b49-b642-e687138d8124.png">

I don't know that it was intended but I've added the possibility. Now the width of the card items is adjustable:

<img width="409" alt="Screenshot 2022-05-13 at 8 36 37" src="https://user-images.githubusercontent.com/4274056/168226944-cf9a66f1-8ec0-43e9-97ff-030aff225311.png">

