### PR TITLE
Add jump to the next text field enhancement to the text fields

### DIFF
--- a/DSKitExplorer/DSKitExplorer/Documentation/ViewModels/TextFields/TextFieldsVC.swift
+++ b/DSKitExplorer/DSKitExplorer/Documentation/ViewModels/TextFields/TextFieldsVC.swift
@@ -31,6 +31,24 @@ class TextFieldsVC: DSViewController {
         let password = DSTextFieldVM(placeholder: "Password")
         password.returnKeyType = .done
         
+        fullName.shouldReturn = { _ in
+            email.isFirstResponder = true
+            
+            return true
+        }
+        
+        email.shouldReturn = { _ in
+            password.isFirstResponder = true
+            
+            return true
+        }
+        
+        password.shouldReturn = { textFieldVM in
+            textFieldVM.isFirstResponder = false
+            
+            return true
+        }
+        
         // Show
         show(content: fullName, email, password)
         
@@ -67,6 +85,24 @@ extension TextFieldsVC: Documentable {
         
         let password = DSTextFieldVM(placeholder: "Password")
         password.returnKeyType = .done
+        
+        fullName.shouldReturn = { _ in
+            email.isFirstResponder = true
+            
+            return true
+        }
+        
+        email.shouldReturn = { _ in
+            password.isFirstResponder = true
+            
+            return true
+        }
+        
+        password.shouldReturn = { textFieldVM in
+            textFieldVM.isFirstResponder = false
+            
+            return true
+        }
         
         // Show
         show(content: fullName, email, password)

--- a/Sources/DSKit/ViewModels/TextField/DSTextFieldUIView.swift
+++ b/Sources/DSKit/ViewModels/TextField/DSTextFieldUIView.swift
@@ -33,6 +33,8 @@ final class DSTextFieldUIView: UIView, DSReusableUIView {
         guard let viewModel = viewModel as? DSTextFieldVM else {
             return
         }
+        viewModel.textField = textField
+        
         self.viewModel = viewModel
         update(viewModel: viewModel)
         updateLayout(viewModel: viewModel)
@@ -289,5 +291,16 @@ final class DSTextFieldUIView: UIView, DSReusableUIView {
     class func instanceFromNib() -> DSTextFieldUIView {
         let view: DSTextFieldUIView = initFromNib()
         return view
+    }
+}
+
+// MARK: - UITextFieldDelegate
+extension DSTextFieldUIView: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let viewModel = viewModel else {
+            return true
+        }
+        
+        return viewModel.shouldReturn?(viewModel) ?? true
     }
 }

--- a/Sources/DSKit/ViewModels/TextField/DSTextFieldUIView.xib
+++ b/Sources/DSKit/ViewModels/TextField/DSTextFieldUIView.xib
@@ -25,6 +25,7 @@
                                 <action selector="editingBegin:" destination="iN0-l3-epB" eventType="editingDidBegin" id="UQQ-UR-CYs"/>
                                 <action selector="editingChange:" destination="iN0-l3-epB" eventType="editingChanged" id="TRL-7l-8p6"/>
                                 <action selector="editingEnd:" destination="iN0-l3-epB" eventType="editingDidEnd" id="NOH-aQ-r4c"/>
+                                <outlet property="delegate" destination="iN0-l3-epB" id="Siy-Sp-CGW"/>
                             </connections>
                         </textField>
                         <label opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wNQ-D5-kZ9">

--- a/Sources/DSKit/ViewModels/TextField/DSTextFieldVM.swift
+++ b/Sources/DSKit/ViewModels/TextField/DSTextFieldVM.swift
@@ -15,6 +15,8 @@ public class DSTextFieldVM: DSViewModel, Equatable, Hashable {
     public var placeholder: String
     public var text: String?
     
+    internal weak var textField: UITextField?
+    
     // Validator
     let validator = DSStringValidator()
     
@@ -83,11 +85,28 @@ public class DSTextFieldVM: DSViewModel, Equatable, Hashable {
     // Textfield type
     public var type: TextFieldViewModelType = .default
     
+    // First responder
+    public var isFirstResponder: Bool {
+        get {
+            return textField?.isFirstResponder ?? false
+        }
+        set {
+            if newValue {
+                textField?.becomeFirstResponder()
+            } else {
+                textField?.resignFirstResponder()
+            }
+        }
+    }
+    
     // Handle did tap
     @NonEquatable public var didTap: ((DSViewModel) -> Void)?
     
     // Handle did update
     @NonEquatable public var didUpdate: ((DSTextFieldVM) -> Void)?
+    
+    // Handle 'return' key press. Return 'false' to ignore.
+    @NonEquatable public var shouldReturn: ((DSTextFieldVM) -> Bool)?
     
     // Handle validation
     @NonEquatable public var handleValidation: ((String?) -> Bool)?


### PR DESCRIPTION
I have a basic solution for **Text field - jump to the next text field** #14 issue.

Let me show you the code how we can configure text fields to enable 'jump to the next field' behavior:

```swift
let fullName = DSTextFieldVM(placeholder: "Full Name")
fullName.returnKeyType = .next
        
let email = DSTextFieldVM(placeholder: "Email")
email.returnKeyType = .next
        
let password = DSTextFieldVM(placeholder: "Password")
password.returnKeyType = .done
        
fullName.shouldReturn = { _ in
    email.isFirstResponder = true
            
    return true
}
        
email.shouldReturn = { _ in
    password.isFirstResponder = true
            
    return true
}
        
password.shouldReturn = { textFieldVM in
    textFieldVM.isFirstResponder = false
            
    return true
}
        
show(content: fullName, email, password)
```

What do you think?