### PR TITLE
Make width and height calculations of the text composer public

### DIFF
--- a/Sources/DSKit/ContentModels/Text/DSTextComposer.swift
+++ b/Sources/DSKit/ContentModels/Text/DSTextComposer.swift
@@ -32,7 +32,7 @@ public class DSTextComposer: Equatable, Hashable {
     }
 }
 
-extension DSTextComposer {
+public extension DSTextComposer {
     
     /// Estimated height for text in section
     /// - Parameters:


### PR DESCRIPTION
I started to develop a custom DSKit viewmodel for myself. It's an expandable/collapsable item. I would use a list of them to show FAQ in a section. Something like this:

![Simulator Screen Shot - iPhone 12 - 2022-05-13 at 15 44 55](https://user-images.githubusercontent.com/4274056/168297565-a20a36e9-9582-4cbd-ad30-d3cb61bb7577.png)

I started the implementation with pure strings. However with time I realized that I could (should) use (reuse) two `DSTextComposer` objects in my custom viewmodel. One for the title and one for the content part. This way the width and height estimations would be much easier for me. However I noticed that the  `estimatedHeight(...` and `calculatedWidth(...` methods of the `DSTextComposer` are only for internal use. I hope we can make them public. 🙂 With this one-liner I could easily implement my custom viewmodel. What do you think?
