### PR TITLE
Make getColor function of DSTextFont public

### DIFF
--- a/Sources/DSKit/ContentModels/Text/DSTextColor.swift
+++ b/Sources/DSKit/ContentModels/Text/DSTextColor.swift
@@ -29,7 +29,7 @@ public enum DSTextColor: Equatable, Hashable {
     /// Get text color
     /// - Parameter designableTextColor: DSDesignableTextColor
     /// - Returns: UIColor
-    func getColor(designableTextColor: DSDesignableTextColor) -> UIColor {        
+    public func getColor(designableTextColor: DSDesignableTextColor) -> UIColor {        
         
         switch self {
         case .largeTitle:


### PR DESCRIPTION
`DSTextFont` has a public function: `func getFont() -> UIFont`, however `DSTextColor`'s `func getColor(designableTextColor: DSDesignableTextColor) -> UIColor` function was not public. Now it is. This way when the user implements a custom DSKit viewmodel they can get a UIColor object from DSTextColor without any issue.